### PR TITLE
chore: add Technical Writers as code owners of api.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @BitGo/developer-experience
+api.yaml @BitGo/developer-experience @BitGo/technical-writers


### PR DESCRIPTION
This commit expands code ownership of `api.yaml` from just DevEx to
DevEx + Technical Writing. For changes that just modify the OpenAPI
specification, our Technical Writers will make great reviewers.