### PR TITLE
chore: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Enable weekly dependency updates for GitHub Actions workflows.

No other package managers detected in the repo (no package.json, Cargo.toml, go.mod, Dockerfile, etc.).

Ticket: DX-535