### PR TITLE
fix: ignore non-method keys in api-diff path iteration

### DIFF
--- a/scripts/api-diff.js
+++ b/scripts/api-diff.js
@@ -8,6 +8,16 @@ const outputPath = process.argv[4] || 'release-description.md';
 const previousSpec = JSON.parse(fs.readFileSync(previousPath, 'utf8'));
 const currentSpec = JSON.parse(fs.readFileSync(currentPath, 'utf8'));
 
+// OpenAPI Path Item Object operation keys. Other keys on a path item
+// (parameters, summary, description, servers, $ref, x-* extensions like
+// x-internal) are NOT operations and must be excluded when iterating methods.
+const HTTP_METHODS = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
+
+function getOperations(pathItem) {
+    if (!pathItem) return [];
+    return Object.entries(pathItem).filter(([key]) => HTTP_METHODS.has(key.toLowerCase()));
+}
+
 // Initialize change tracking
 const changes = {
     added: {},      // Group by path
@@ -48,7 +58,7 @@ function checkSimilarity(endpoint1, endpoint2) {
     if (endpoint1.details.summary && endpoint2.details.summary && endpoint1.details.summary === endpoint2.details.summary) {
         similarityScore += 1;
     }
-    if (endpoint1.details.description && endpoint1.details.description && endpoint1.details.description === endpoint2.details.description) {
+    if (endpoint1.details.description && endpoint2.details.description && endpoint1.details.description === endpoint2.details.description) {
         similarityScore += 1;
     }
 
@@ -157,7 +167,7 @@ function findAffectedPaths() {
     if (changes.components.size === 0) return;
 
     Object.entries(currentSpec.paths || {}).forEach(([path, methods]) => {
-        Object.entries(methods).forEach(([method, details]) => {
+        getOperations(methods).forEach(([method, details]) => {
             const usedComponents = new Set();
             findComponentRefs(details, usedComponents);
             
@@ -183,8 +193,8 @@ function comparePaths() {
     // Check for added and modified endpoints
     Object.entries(currentSpec.paths || {}).forEach(([path, methods]) => {
         const previousMethods = previousSpec.paths?.[path] || {};
-        
-        Object.entries(methods).forEach(([method, details]) => {
+
+        getOperations(methods).forEach(([method, details]) => {
             if (!previousMethods[method]) {
                 if (!changes.added[path]) changes.added[path] = new Set();
                 changes.added[path].add(method.toUpperCase());
@@ -203,7 +213,7 @@ function comparePaths() {
 
     // Check for removed endpoints
     Object.entries(previousSpec.paths || {}).forEach(([path, methods]) => {
-        Object.keys(methods).forEach(method => {
+        getOperations(methods).forEach(([method]) => {
             if (!currentSpec.paths?.[path]?.[method]) {
                 if (!changes.removed[path]) changes.removed[path] = new Set();
                 changes.removed[path].add(method.toUpperCase());

--- a/tests/fixtures/path-level-extensions/current.json
+++ b/tests/fixtures/path-level-extensions/current.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.3",
+  "info": { "title": "Test API", "version": "1.0.0" },
+  "paths": {
+    "/widgets": {
+      "x-internal": false,
+      "summary": "Widget operations",
+      "parameters": [
+        {
+          "name": "traceId",
+          "in": "header",
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "operationId": "listWidgets",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/path-level-extensions/previous.json
+++ b/tests/fixtures/path-level-extensions/previous.json
@@ -1,0 +1,16 @@
+{
+  "openapi": "3.0.3",
+  "info": { "title": "Test API", "version": "1.0.0" },
+  "paths": {
+    "/widgets": {
+      "get": {
+        "operationId": "listWidgets",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Filter path-item iteration to actual HTTP methods so path-level keys like `x-internal`, `parameters`, `summary`, etc. don't get reported as endpoint changes (was producing spurious `[X-INTERNAL] /api/v2/{coin}/wallet/{walletId}/webhooks/notifications` entries in release notes).
- Fix a self-comparison typo in `checkSimilarity()` — the description-similarity check was comparing `endpoint1.details.description` to itself instead of `endpoint2.details.description`.
- Add a `path-level-extensions` test fixture covering path-level `x-internal`, `summary`, and `parameters`.

## Test plan
- [x] `node --test tests/generate-release.test.js` — 14/14 pass (13 existing + 1 new fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)